### PR TITLE
Revert "Made modifications to prevent the "OCR_" prefix for result descriptions."

### DIFF
--- a/Config/dcm_instance/ocr_alokag8_instance.json
+++ b/Config/dcm_instance/ocr_alokag8_instance.json
@@ -7,10 +7,8 @@
         "qc_series": {
             "filters": {}, 
             "params": {
-                "ocr_regions": {
-                    "probeID:type": "string",
-                    "probeID:xywh": "676;167;34;15"
-                },
+                "OCR_probeID:type": "string", 
+                "OCR_probeID:xywh": "676;167;34;15", 
                 "channel": 2, 
                 "ocr_threshold": 80, 
                 "ocr_zoom": 2

--- a/Config/dcm_instance/ocr_intevo_lehr.json
+++ b/Config/dcm_instance/ocr_intevo_lehr.json
@@ -7,16 +7,14 @@
         "qc_series": {
             "filters": {}, 
             "params": {
-                "ocr_regions": {
-                    "Detector:prefix": "Detector",
-                    "Detector:type": "float",
-                    "Detector:xywh": "25;120;100;25",
-                    "Integral Uniformity:suffix": "%",
-                    "Integral Uniformity:type": "float",
-                    "Integral Uniformity:xywh": "882;294;100;25",
-                    "Label:type": "string",
-                    "Label:xywh": "64;416;200;25"
-                },
+                "OCR_Detector:prefix": "Detector", 
+                "OCR_Detector:type": "float", 
+                "OCR_Detector:xywh": "25;120;100;25", 
+                "OCR_Integral:suffix": "%", 
+                "OCR_Integral:type": "float", 
+                "OCR_Integral:xywh": "882;294;100;25", 
+                "OCR_Label:type": "string", 
+                "OCR_Label:xywh": "64;416;200;25", 
                 "channel": "avg", 
                 "slicenr": -1
             }

--- a/Config/dcm_instance/ocr_philips_epiq_instance.json
+++ b/Config/dcm_instance/ocr_philips_epiq_instance.json
@@ -7,14 +7,12 @@
         "qc_series": {
             "filters": {}, 
             "params": {
-                "ocr_regions": {
-                    "MechIndex:prefix": "MI",
-                    "MechIndex:type": "float",
-                    "MechIndex:xywh": "913;22;80;25",
-                    "TissueIndex:prefix": "TIS",
-                    "TissueIndex:type": "float",
-                    "TissueIndex:xywh": "822;22;90;25"
-                }
+                "OCR_MechIndex:prefix": "MI", 
+                "OCR_MechIndex:type": "float", 
+                "OCR_MechIndex:xywh": "913;22;80;25", 
+                "OCR_TissueIndex:prefix": "TIS", 
+                "OCR_TissueIndex:type": "float", 
+                "OCR_TissueIndex:xywh": "822;22;90;25"
             }
         }
     }, 

--- a/ocr_wadwrapper.py
+++ b/ocr_wadwrapper.py
@@ -153,30 +153,30 @@ def OCR(data, results, action):
     slicenr = params.get('slicenr', -1)
     ocr_threshold = params.get('ocr_threshold', 0)
     ocr_zoom = params.get('ocr_zoom', 10)
-    ocr_regions = params.get('ocr_regions',{})
 
     inputfile = data.series_filelist[0][0] # only single images 
     dcmInfile, pixeldataIn = readdcm(inputfile, channel, slicenr)
 
     # solve ocr params
     regions = {}
-    for k,v in ocr_regions.items():
+    for k,v in params.items():
         #'OCR_TissueIndex:xywh' = 'x;y;w;h'
         #'OCR_TissueIndex:prefix' = 'prefix'
         #'OCR_TissueIndex:suffix' = 'suffix'
-        split = k.find(':')
-        name = k[:split]
-        stuff = k[split+1:]
-        if not name in regions:
-            regions[name] = {'prefix':'', 'suffix':''}
-        if stuff == 'xywh':
-            regions[name]['xywh'] = [int(p) for p in v.split(';')]
-        elif stuff == 'prefix':
-            regions[name]['prefix'] = v
-        elif stuff == 'suffix':
-            regions[name]['suffix'] = v
-        elif stuff == 'type':
-            regions[name]['type'] = v
+        if k.startswith('OCR_'):
+            split = k.find(':')
+            name = k[:split]
+            stuff = k[split+1:]
+            if not name in regions:
+                regions[name] = {'prefix':'', 'suffix':''}
+            if stuff == 'xywh':
+                regions[name]['xywh'] = [int(p) for p in v.split(';')]
+            elif stuff == 'prefix':
+                regions[name]['prefix'] = v
+            elif stuff == 'suffix':
+                regions[name]['suffix'] = v
+            elif stuff == 'type':
+                regions[name]['type'] = v
 
     for name, region in regions.items():
         txt, part = ocr_lib.OCR(pixeldataIn, region['xywh'], ocr_zoom=ocr_zoom, ocr_threshold=ocr_threshold, transposed=False)


### PR DESCRIPTION
Reverts MedPhysQC/Generic_OCR#3
This breaks wad_admin, which expects params to be a simple dict, not a nested dict. So wad_admin should be changed first.